### PR TITLE
Updated Elden Ring NT patches

### DIFF
--- a/_patches/FD4-NTS-Orbis.md
+++ b/_patches/FD4-NTS-Orbis.md
@@ -70,7 +70,7 @@ In file `eboot.bin`
 
 ## Bypass Network Check
 
-Author: Unknown
+Author: [Whitehawkx](https://twitter.com/Whitehawkx)
 
 In file `eboot.bin`
 
@@ -78,9 +78,7 @@ In file `eboot.bin`
 <summary>Code (Click to Expand)</summary>
 
 ```
-0x015724A0 90 90 90 90 90 90
-0x015725AC 90 90 90 90 90 90
-0x015724B1 E9 EF 00 00 00 90
+0x015724A0 E9 00 01
 ```
 
 </details>

--- a/_patches/FD4-NTS-Orbis.md
+++ b/_patches/FD4-NTS-Orbis.md
@@ -98,28 +98,11 @@ In file `eboot.bin`
 
 </details>
 
-## Enable video recording
+## Enable video recording and screenshots
 
-Re-enables built-in video recording (share button)
+Re-enables built-in video recording and screenshots (share button)
 
-Author: Whitehawkx
-
-In file `eboot.bin`
-
-<details>
-<summary>Code (Click to Expand)</summary>
-
-```
-0x01BFF78E 90 90 90 90 90
-```
-
-</details>
-
-## Enable screenshots
-
-Re-enables built-in screenshot capture (share button)
-
-Author: Whitehawkx
+Author: [Whitehawkx](https://twitter.com/Whitehawkx)
 
 In file `eboot.bin`
 
@@ -127,7 +110,7 @@ In file `eboot.bin`
 <summary>Code (Click to Expand)</summary>
 
 ```
-0x01BFF7AC 90 90 90 90 90
+0x01BFF799 00
 ```
 
 </details>


### PR DESCRIPTION
I updated the patches to bypass the network check and enable video recording and screenshots. Functionally they're still the same. These patches just require fewer changed bytes. I left the game running for an hour while logged in to be sure no additional checks come up.